### PR TITLE
[main] fix: support direct github.com connection in SSH config

### DIFF
--- a/.config/nix/home-manager/programs/ssh.nix
+++ b/.config/nix/home-manager/programs/ssh.nix
@@ -11,10 +11,9 @@
         serverAliveCountMax = 5;
       };
 
-      "github" = {
+      "github.com github" = {
         hostname = "github.com";
         user = "git";
-        port = 22;
         addKeysToAgent = "yes";
         identityFile = "~/.ssh/id_ed25519_github";
         identitiesOnly = true;


### PR DESCRIPTION
- Add github.com as matching host alongside github alias
- Remove unnecessary port = 22 specification (SSH default)
- Fixes git pull/push without prior ssh github command