### PR TITLE
[main] chore: add DO_NOT_TRACK environment variable

### DIFF
--- a/.config/nix/home-manager/programs/zsh.nix
+++ b/.config/nix/home-manager/programs/zsh.nix
@@ -60,6 +60,7 @@
       export LANG="''${LANGUAGE}"
       export LC_ALL="''${LANGUAGE}"
       export LC_CTYPE="''${LANGUAGE}"
+      export DO_NOT_TRACK=1
     '';
 
     # .zshrc content (full control)


### PR DESCRIPTION
- Add DO_NOT_TRACK=1 to zsh environment variables
- Disables telemetry collection for CLI tools and applications
- Set in .zshenv to apply to all shell instances