### PR TITLE
[main] feat: add Sheldon zsh plugin manager

### DIFF
--- a/.config/nix/home-manager/default.nix
+++ b/.config/nix/home-manager/default.nix
@@ -10,6 +10,7 @@
     ./programs/git.nix
     ./programs/gpg.nix
     ./programs/mise.nix
+    ./programs/sheldon.nix
     ./programs/ssh.nix
     ./programs/starship.nix
     ./programs/zsh.nix

--- a/.config/nix/home-manager/programs/sheldon.nix
+++ b/.config/nix/home-manager/programs/sheldon.nix
@@ -1,0 +1,26 @@
+{ ... }:
+
+{
+  programs.sheldon = {
+    enable = true;
+    enableZshIntegration = true;
+
+    settings = {
+      shell = "zsh";
+
+      plugins = {
+        zsh-autosuggestions = {
+          github = "zsh-users/zsh-autosuggestions";
+        };
+
+        zsh-completions = {
+          github = "zsh-users/zsh-completions";
+        };
+
+        fast-syntax-highlighting = {
+          github = "zdharma-continuum/fast-syntax-highlighting";
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
- Add Sheldon configuration for declarative zsh plugin management
- Include zsh-autosuggestions for command history autocompletion
- Include zsh-completions for additional shell completion definitions
- Include fast-syntax-highlighting for command syntax highlighting