### PR TITLE
[main] refactor: centralize darwin-rebuild aliases using hostSpec

### DIFF
--- a/.config/nix/home-manager/programs/zsh.nix
+++ b/.config/nix/home-manager/programs/zsh.nix
@@ -1,5 +1,8 @@
-{ config, ... }:
+{ config, hostSpec, ... }:
 
+let
+  flakePath = "~/projects/github.com/kkhys/dotfiles/.config/nix";
+in
 {
   programs.zsh = {
     enable = true;
@@ -17,6 +20,10 @@
 
     # Shell aliases (auto-expanded by Home Manager)
     shellAliases = {
+      # Nix darwin-rebuild
+      dr = "sudo darwin-rebuild switch --flake ${flakePath}#${hostSpec.hostName}";
+      drb = "sudo darwin-rebuild build --flake ${flakePath}#${hostSpec.hostName}";
+      drc = "sudo darwin-rebuild check --flake ${flakePath}#${hostSpec.hostName}";
       # Directory navigation
       ".." = "cd ..";
       "..." = "../../";

--- a/.config/nix/hosts/personal/default.nix
+++ b/.config/nix/hosts/personal/default.nix
@@ -17,12 +17,4 @@
 
   # environment.systemPackages = with pkgs; [
   # ];
-
-  home-manager.users.${config.hostSpec.username} = {
-    programs.zsh.shellAliases = {
-      dr = "sudo darwin-rebuild switch --flake ~/projects/github.com/kkhys/dotfiles/.config/nix#personal";
-      drb = "sudo darwin-rebuild build --flake ~/projects/github.com/kkhys/dotfiles/.config/nix#personal";
-      drc = "sudo darwin-rebuild check --flake ~/projects/github.com/kkhys/dotfiles/.config/nix#personal";
-    };
-  };
 }

--- a/.config/nix/hosts/work/default.nix
+++ b/.config/nix/hosts/work/default.nix
@@ -17,12 +17,4 @@
 
   # environment.systemPackages = with pkgs; [
   # ];
-
-  home-manager.users.${config.hostSpec.username} = {
-    programs.zsh.shellAliases = {
-      dr = "sudo darwin-rebuild switch --flake ~/projects/github.com/kkhys/dotfiles/.config/nix#work";
-      drb = "sudo darwin-rebuild build --flake ~/projects/github.com/kkhys/dotfiles/.config/nix#work";
-      drc = "sudo darwin-rebuild check --flake ~/projects/github.com/kkhys/dotfiles/.config/nix#work";
-    };
-  };
 }


### PR DESCRIPTION
- Centralize darwin-rebuild aliases (dr, drb, drc) in zsh configuration
- Use hostSpec.hostName for dynamic host identification
- Remove duplicate host-specific alias definitions from personal and work hosts
- Improve maintainability by eliminating code duplication