### PR TITLE
[main] chore: adjust git push permission from deny to ask

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -18,7 +18,6 @@
       "Skill(base:*)"
     ],
     "deny": [
-      "Bash(git push:*)",
       "Bash(rm -rf:*)",
       "Bash(sudo:*)",
       "Bash(curl:*)",
@@ -64,6 +63,7 @@
       "Write(.env*)"
     ],
     "ask": [
+      "Bash(git push:*)",
       "Bash(git rebase:*)",
       "Bash(git reset:*)",
       "Bash(gh pr create:*)",


### PR DESCRIPTION
- Move git push permission from deny to ask in Claude Code settings
- This allows prompting user before executing git push commands