### PR TITLE
main: chore: add Codex configuration

### DIFF
--- a/.config/codex/config.toml
+++ b/.config/codex/config.toml
@@ -1,0 +1,2 @@
+model = "gpt-5.2-codex"
+model_reasoning_effort = "medium"

--- a/.config/nix/home-manager/dotfiles.nix
+++ b/.config/nix/home-manager/dotfiles.nix
@@ -21,6 +21,11 @@ let
   geminiFiles = [
     "settings.json"
   ];
+
+  # Codex config files (stored in .config/codex/, linked to ~/.codex/)
+  codexFiles = [
+    "config.toml"
+  ];
 in
 {
   xdg.configFile = lib.genAttrs configFiles (file: {
@@ -33,7 +38,10 @@ in
   }) claudeFiles) // builtins.listToAttrs (map (file: {
     name = ".gemini/${file}";
     value = { source = mkLink ".config/gemini/${file}"; };
-  }) geminiFiles) // {
+  }) geminiFiles) // builtins.listToAttrs (map (file: {
+    name = ".codex/${file}";
+    value = { source = mkLink ".config/codex/${file}"; };
+  }) codexFiles) // {
     # SSH public key
     ".ssh/id_ed25519_github.pub".source = mkLink ".config/nix/secrets/id_ed25519_github.pub";
   };


### PR DESCRIPTION
## Summary

- Add Codex configuration file (`.config/codex/config.toml`)
- Add symlink configuration in Home Manager dotfiles module
- Configure gpt-5.2-codex model with medium reasoning effort

## Test plan

- [x] Run `darwin-rebuild switch` to apply configuration
- [x] Verify `~/.codex/config.toml` symlink is created
- [x] Verify Codex uses the configured model and settings