### PR TITLE
[main] chore: move aqua-voice to personal homebrew configuration

### DIFF
--- a/.config/nix/hosts/common/homebrew-personal.nix
+++ b/.config/nix/hosts/common/homebrew-personal.nix
@@ -8,6 +8,7 @@
 
     casks = [
       "adobe-creative-cloud"
+      "aqua-voice"
     ];
   };
 }

--- a/.config/nix/hosts/common/homebrew.nix
+++ b/.config/nix/hosts/common/homebrew.nix
@@ -7,7 +7,6 @@
     ];
 
     casks = [
-      "aqua-voice"
       "google-chrome"
       "karabiner-elements"
       "logi-options+"


### PR DESCRIPTION
- Move aqua-voice cask from common to personal homebrew configuration
- Ensures personal-only packages are properly isolated in personal environment