### PR TITLE
[main] chore: disable zed markdown edit predictions

### DIFF
--- a/.config/zed/settings.json
+++ b/.config/zed/settings.json
@@ -55,5 +55,10 @@
     "mode": "dark",
     "light": "Catppuccin Mocha",
     "dark": "Catppuccin Mocha"
+  },
+  "languages": {
+    "Markdown": {
+      "show_edit_predictions": false
+    }
   }
 }


### PR DESCRIPTION
- Disable Zed editor's edit predictions for Markdown files