### PR TITLE
[main] chore: enable experimental agent teams feature

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "env": {
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "0"
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "attribution": {
     "commit": "Co-Authored-By: Claude <noreply@anthropic.com>",


### PR DESCRIPTION
- Enable CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS environment variable
- Activate multi-agent orchestration feature in Claude Code
- Allow coordinating multiple Claude Code sessions as a team