### PR TITLE
[main] chore: add Docker CLI plugins configuration for work environment

### DIFF
--- a/.config/nix/home-manager/dotfiles.nix
+++ b/.config/nix/home-manager/dotfiles.nix
@@ -1,4 +1,4 @@
-{ config, lib, ... }:
+{ config, lib, hostSpec, ... }:
 
 let
   dotfilesPath = "${config.home.homeDirectory}/projects/github.com/kkhys/dotfiles";
@@ -44,5 +44,19 @@ in
   }) codexFiles) // {
     # SSH public key
     ".ssh/id_ed25519_github.pub".source = mkLink ".config/nix/secrets/id_ed25519_github.pub";
+  };
+
+  # Docker CLI plugins symlinks (work environment only)
+  # Uses activation script because Homebrew binaries may not exist at build time
+  home.activation = lib.mkIf hostSpec.isWork {
+    dockerCliPlugins = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      mkdir -p "$HOME/.docker/cli-plugins"
+      if [ -f "/opt/homebrew/opt/docker-compose/bin/docker-compose" ]; then
+        ln -sfn "/opt/homebrew/opt/docker-compose/bin/docker-compose" "$HOME/.docker/cli-plugins/docker-compose"
+      fi
+      if [ -f "/opt/homebrew/opt/docker-buildx/bin/docker-buildx" ]; then
+        ln -sfn "/opt/homebrew/opt/docker-buildx/bin/docker-buildx" "$HOME/.docker/cli-plugins/docker-buildx"
+      fi
+    '';
   };
 }

--- a/.config/nix/hosts/common/homebrew-work.nix
+++ b/.config/nix/hosts/common/homebrew-work.nix
@@ -2,6 +2,12 @@
 
 {
   homebrew = lib.mkIf config.hostSpec.isWork {
+    brews = [
+      "docker"
+      "docker-compose"
+      "docker-buildx"
+    ];
+
     casks = [
       "microsoft-edge"
       "openvpn-connect"


### PR DESCRIPTION
- Install Docker, docker-compose, and docker-buildx via Homebrew
- Configure Docker CLI plugins symlinks in ~/.docker/cli-plugins
- Add Home Manager activation script for work environment setup