### PR TITLE
[main] chore: add rustup to development tools

### DIFF
--- a/.config/nix/home-manager/packages.nix
+++ b/.config/nix/home-manager/packages.nix
@@ -8,6 +8,7 @@
     lefthook
 
     # Development Tools
+    rustup
     uv
 
     # Editor


### PR DESCRIPTION
- Add rustup (Rust toolchain manager) to development tools packages