### PR TITLE
[main] chore: add entire CLI

### DIFF
--- a/.config/nix/darwin/homebrew.nix
+++ b/.config/nix/darwin/homebrew.nix
@@ -11,6 +11,7 @@
       "homebrew/core"
       "homebrew/cask"
       "protonpass/tap"
+      "entireio/tap"
     ];
   };
 }

--- a/.config/nix/hosts/common/homebrew.nix
+++ b/.config/nix/hosts/common/homebrew.nix
@@ -13,6 +13,7 @@
       "obsidian"
       "ghostty"
       "zed"
+      "entireio/tap/entire"
     ];
   };
 }


### PR DESCRIPTION
## Summary

Add Entire CLI to the Nix/Homebrew-based dotfiles configuration.

## Changes

- Add `entireio/tap` to Homebrew taps in `.config/nix/darwin/homebrew.nix`
- Add `entireio/tap/entire` cask to `.config/nix/hosts/common/homebrew.nix`

## Details

Entire is a developer platform that integrates with Git workflows to capture AI agent (Claude Code, Gemini CLI, OpenCode) sessions. It creates a searchable record linking code changes with their context and reasoning.

## Testing

Apply with:
```bash
sudo darwin-rebuild switch --flake ~/projects/github.com/kkhys/dotfiles/.config/nix#personal
```

This will install the entire CLI via Homebrew.