### PR TITLE
[main] chore(claude): enable Slack plugin

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -93,8 +93,9 @@
     "padding": 0
   },
   "enabledPlugins": {
-    "base@my-marketplace": true
+    "base@my-marketplace": true,
+    "slack@claude-plugins-official": true
   },
-  "promptSuggestionEnabled": false,
-  "effortLevel": "high"
+  "effortLevel": "high",
+  "promptSuggestionEnabled": false
 }


### PR DESCRIPTION
## Summary
- Enable Slack plugin in Claude Code settings

## Test plan
- [x] Verify settings are correctly applied with `darwin-rebuild switch`