### PR TITLE
[main] chore(claude): enable additional plugins

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -94,7 +94,14 @@
   },
   "enabledPlugins": {
     "base@my-marketplace": true,
-    "slack@claude-plugins-official": true
+    "slack@claude-plugins-official": true,
+    "ralph-loop@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true
   },
   "effortLevel": "high",
   "promptSuggestionEnabled": false


### PR DESCRIPTION
## Summary
- Enable additional Claude Code plugins: ralph-loop, code-review, code-simplifier, security-guidance, pr-review-toolkit, frontend-design, claude-md-management

## Test plan
- [x] Verify settings are correctly applied via `darwin-rebuild switch`