### PR TITLE
[main] chore: add RTK hook

### DIFF
--- a/.config/claude/CLAUDE.md
+++ b/.config/claude/CLAUDE.md
@@ -18,3 +18,5 @@
 
 ## Proactive
 - Suggest improvements proactively
+
+@RTK.md

--- a/.config/claude/RTK.md
+++ b/.config/claude/RTK.md
@@ -1,0 +1,29 @@
+# RTK - Rust Token Killer
+
+**Usage**: Token-optimized CLI proxy (60-90% savings on dev operations)
+
+## Meta Commands (always use rtk directly)
+
+```bash
+rtk gain              # Show token savings analytics
+rtk gain --history    # Show command usage history with savings
+rtk discover          # Analyze Claude Code history for missed opportunities
+rtk proxy <cmd>       # Execute raw command without filtering (for debugging)
+```
+
+## Installation Verification
+
+```bash
+rtk --version         # Should show: rtk X.Y.Z
+rtk gain              # Should work (not "command not found")
+which rtk             # Verify correct binary
+```
+
+⚠️ **Name collision**: If `rtk gain` fails, you may have reachingforthejack/rtk (Rust Type Kit) installed instead.
+
+## Hook-Based Usage
+
+All other commands are automatically rewritten by the Claude Code hook.
+Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
+
+Refer to CLAUDE.md for full command reference.

--- a/.config/claude/hooks/rtk-rewrite.sh
+++ b/.config/claude/hooks/rtk-rewrite.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# rtk-hook-version: 2
+# RTK Claude Code hook — rewrites commands to use rtk for token savings.
+# Requires: rtk >= 0.23.0, jq
+#
+# This is a thin delegating hook: all rewrite logic lives in `rtk rewrite`,
+# which is the single source of truth (src/discover/registry.rs).
+# To add or change rewrite rules, edit the Rust registry — not this file.
+
+if ! command -v jq &>/dev/null; then
+  echo "[rtk] WARNING: jq is not installed. Hook cannot rewrite commands. Install jq: https://jqlang.github.io/jq/download/" >&2
+  exit 0
+fi
+
+if ! command -v rtk &>/dev/null; then
+  echo "[rtk] WARNING: rtk is not installed or not in PATH. Hook cannot rewrite commands. Install: https://github.com/rtk-ai/rtk#installation" >&2
+  exit 0
+fi
+
+# Version guard: rtk rewrite was added in 0.23.0.
+# Older binaries: warn once and exit cleanly (no silent failure).
+RTK_VERSION=$(rtk --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+if [ -n "$RTK_VERSION" ]; then
+  MAJOR=$(echo "$RTK_VERSION" | cut -d. -f1)
+  MINOR=$(echo "$RTK_VERSION" | cut -d. -f2)
+  # Require >= 0.23.0
+  if [ "$MAJOR" -eq 0 ] && [ "$MINOR" -lt 23 ]; then
+    echo "[rtk] WARNING: rtk $RTK_VERSION is too old (need >= 0.23.0). Upgrade: cargo install rtk" >&2
+    exit 0
+  fi
+fi
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ -z "$CMD" ]; then
+  exit 0
+fi
+
+# Delegate all rewrite logic to the Rust binary.
+# rtk rewrite exits 1 when there's no rewrite — hook passes through silently.
+REWRITTEN=$(rtk rewrite "$CMD" 2>/dev/null) || exit 0
+
+# No change — nothing to do.
+if [ "$CMD" = "$REWRITTEN" ]; then
+  exit 0
+fi
+
+ORIGINAL_INPUT=$(echo "$INPUT" | jq -c '.tool_input')
+UPDATED_INPUT=$(echo "$ORIGINAL_INPUT" | jq --arg cmd "$REWRITTEN" '.command = $cmd')
+
+jq -n \
+  --argjson updated "$UPDATED_INPUT" \
+  '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "allow",
+      "permissionDecisionReason": "RTK auto-rewrite",
+      "updatedInput": $updated
+    }
+  }'

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -104,5 +104,18 @@
     "claude-md-management@claude-plugins-official": true
   },
   "effortLevel": "high",
-  "promptSuggestionEnabled": false
+  "promptSuggestionEnabled": false,
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/rtk-rewrite.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/.config/nix/home-manager/dotfiles.nix
+++ b/.config/nix/home-manager/dotfiles.nix
@@ -14,7 +14,9 @@ let
   # Claude config files (stored in .config/claude/, linked to ~/.claude/)
   claudeFiles = [
     "CLAUDE.md"
+    "RTK.md"
     "settings.json"
+    "hooks/rtk-rewrite.sh"
   ];
 
   # Gemini config files (stored in .config/gemini/, linked to ~/.gemini/)

--- a/.config/nix/hosts/common/homebrew.nix
+++ b/.config/nix/hosts/common/homebrew.nix
@@ -4,6 +4,7 @@
   homebrew = {
     brews = [
       "protonpass/tap/pass-cli"
+      "rtk"
     ];
 
     casks = [


### PR DESCRIPTION
## Summary

- Add `rtk` Homebrew package to common brew packages
- Add RTK (Rust Token Killer) hook configuration for Claude Code to automatically rewrite CLI commands for token-optimized output
- Add RTK.md documentation and symlink management via Home Manager

## Test plan

- [x] `darwin-rebuild switch` completes successfully
- [x] `rtk --version` returns expected version
- [x] Claude Code hook rewrites commands via `rtk rewrite`