### PR TITLE
[main] chore: add cmux terminal

### DIFF
--- a/.config/nix/darwin/homebrew.nix
+++ b/.config/nix/darwin/homebrew.nix
@@ -13,6 +13,7 @@
       "protonpass/tap"
       "entireio/tap"
       "datadog-labs/pack"
+      "manaflow-ai/cmux"
     ];
   };
 }

--- a/.config/nix/hosts/common/homebrew.nix
+++ b/.config/nix/hosts/common/homebrew.nix
@@ -15,6 +15,7 @@
       "ghostty"
       "zed"
       "entireio/tap/entire"
+      "manaflow-ai/cmux/cmux"
     ];
   };
 }


### PR DESCRIPTION
## Summary
- Add cmux (Ghostty-based macOS terminal with vertical tabs and notifications) tap and cask to Homebrew

## Test plan
- [x] Verify cmux installs successfully via `darwin-rebuild switch`