### PR TITLE
[main] chore: add CleanShot X screenshot tool

### DIFF
--- a/.config/nix/hosts/common/homebrew.nix
+++ b/.config/nix/hosts/common/homebrew.nix
@@ -16,6 +16,7 @@
       "zed"
       "entireio/tap/entire"
       "manaflow-ai/cmux/cmux"
+      "cleanshot"
     ];
   };
 }


### PR DESCRIPTION
## Summary
- Add `cleanshot` cask to common Homebrew packages

## Test plan
- [x] Run `darwin-rebuild switch` to verify CleanShot X is installed via Homebrew