### PR TITLE
[main] feat: add custom statusline script for Claude Code

### DIFF
--- a/.config/claude/settings-work.json
+++ b/.config/claude/settings-work.json
@@ -101,7 +101,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "bun x ccusage statusline",
+    "command": "bash ~/.claude/statusline-command.sh",
     "padding": 0
   },
   "enabledPlugins": {

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -89,7 +89,7 @@
   "model": "opus[1m]",
   "statusLine": {
     "type": "command",
-    "command": "bun x ccusage statusline",
+    "command": "~/.claude/statusline-command.sh",
     "padding": 0
   },
   "enabledPlugins": {

--- a/.config/claude/statusline-command.sh
+++ b/.config/claude/statusline-command.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Claude Code statusLine script
-# Output format: Sonnet 4.6 | 10.2K tkns. (20%)
+# Output format: Sonnet 4.6 | main | 10.2K (20%)
 
 input=$(cat)
 

--- a/.config/claude/statusline-command.sh
+++ b/.config/claude/statusline-command.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Claude Code statusLine script
+# Output format: Sonnet 4.6 | 10.2K tkns. (20%)
+
+input=$(cat)
+
+model=$(echo "$input" | jq -r '.model.display_name // "Unknown"' | sed 's/^Claude //')
+
+used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+ctx_size=$(echo "$input" | jq -r '.context_window.context_window_size // empty')
+# used_tokens = input + cache_creation + cache_read (matches used_percentage formula per docs)
+used_tokens=$(echo "$input" | jq -r '
+  (.context_window.current_usage.input_tokens // 0)
+  + (.context_window.current_usage.cache_creation_input_tokens // 0)
+  + (.context_window.current_usage.cache_read_input_tokens // 0)
+  | if . == 0 then empty else . end
+')
+
+branch=$(git branch --show-current 2>/dev/null)
+branch_part=${branch:+" | $branch"}
+
+if [[ -n "$used_pct" && -n "$used_tokens" ]]; then
+  pct=$(printf "%.0f" "$used_pct")
+  fmt_k=$(awk "BEGIN {printf \"%.1fK\", $used_tokens / 1000}" | sed 's/\.0K/K/')
+
+  if [[ "$pct" -ge 90 ]]; then color='\033[31m'
+  elif [[ "$pct" -ge 70 ]]; then color='\033[33m'
+  else color='\033[32m'; fi
+
+  printf "%s%s | %s (%b%s%%\033[0m)" "$model" "$branch_part" "$fmt_k" "$color" "$pct"
+else
+  printf "%s%s | --" "$model" "$branch_part"
+fi

--- a/.config/nix/home-manager/dotfiles.nix
+++ b/.config/nix/home-manager/dotfiles.nix
@@ -16,6 +16,7 @@ let
     "CLAUDE.md"
     "RTK.md"
     "hooks/rtk-rewrite.sh"
+    "statusline-command.sh"
   ];
 
   claudeSettingsFile = if hostSpec.isWork then "settings-work.json" else "settings.json";


### PR DESCRIPTION
- Add statusline-command.sh that displays model name, context usage percentage, token count, and current git branch
- Color-code context usage warnings (green < 70%, yellow < 90%, red >= 90%)
- Update personal and work settings to reference the new script
- Add script to home-manager dotfiles symlink management