### PR TITLE
[main] chore: add zed shortcut alias

### DIFF
--- a/.config/nix/home-manager/programs/zsh.nix
+++ b/.config/nix/home-manager/programs/zsh.nix
@@ -45,6 +45,7 @@ in
       # Tools
       v = "vim";
       g = "git";
+      "z." = "zed .";
 
       # Docker
       dc = "docker compose";


### PR DESCRIPTION
- Add `z.` alias for `zed .` to open current directory in Zed editor