### PR TITLE
[main] chore: remove unused plugins from work settings

### DIFF
--- a/.config/claude/settings-work.json
+++ b/.config/claude/settings-work.json
@@ -113,10 +113,7 @@
     "security-guidance@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true,
-    "design-review@revcomm": true,
-    "miitel-softphone@revcomm": true,
-    "miitel-analytics-frontend@revcomm": true
+    "claude-md-management@claude-plugins-official": true
   },
   "effortLevel": "high",
   "promptSuggestionEnabled": false


### PR DESCRIPTION
- Remove design-review, miitel-softphone, and miitel-analytics-frontend plugins from work Claude settings