### PR TITLE
[main] chore(claude): enable additional official plugins

### DIFF
--- a/.config/claude/settings-work.json
+++ b/.config/claude/settings-work.json
@@ -86,6 +86,7 @@
       "Bash(aws cloudformation update-stack:*)"
     ]
   },
+  "model": "opus[1m]",
   "hooks": {
     "PreToolUse": [
       {

--- a/.config/claude/settings-work.json
+++ b/.config/claude/settings-work.json
@@ -114,7 +114,16 @@
     "security-guidance@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true
+    "claude-md-management@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true,
+    "plugin-dev@claude-plugins-official": true,
+    "Notion@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "figma@claude-plugins-official": true,
+    "serena@claude-plugins-official": true,
+    "hookify@claude-plugins-official": true,
+    "sentry@claude-plugins-official": true
   },
   "effortLevel": "high",
   "promptSuggestionEnabled": false

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -113,7 +113,13 @@
     "security-guidance@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true
+    "claude-md-management@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true,
+    "plugin-dev@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "serena@claude-plugins-official": true,
+    "hookify@claude-plugins-official": true
   },
   "promptSuggestionEnabled": false,
   "effortLevel": "high"


### PR DESCRIPTION
## Summary
- Add opus model setting to work environment configuration
- Enable additional official plugins (skill-creator, plugin-dev, context7, playwright, serena, hookify, etc.) for both personal and work environments

## Test plan
- [x] Verify JSON syntax is valid for both `settings.json` and `settings-work.json`
- [x] Confirm plugins load correctly when launching Claude Code