### PR TITLE
[main] chore: replace wildcard skill permission with explicit entries

### DIFF
--- a/.config/claude/settings-work.json
+++ b/.config/claude/settings-work.json
@@ -20,7 +20,10 @@
       "mcp__serena",
       "mcp__playwright",
       "mcp__plugin_base_serena__*",
-      "Skill(base:*)"
+      "Skill(creating-branch-name)",
+      "Skill(splitting-commit)",
+      "Skill(formatting-commit)",
+      "Skill(creating-pr)"
     ],
     "deny": [
       "Bash(rm -rf:*)",

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -20,7 +20,10 @@
       "mcp__serena",
       "mcp__playwright",
       "mcp__plugin_base_serena__*",
-      "Skill(base:*)"
+      "Skill(creating-branch-name)",
+      "Skill(splitting-commit)",
+      "Skill(formatting-commit)",
+      "Skill(creating-pr)"
     ],
     "deny": [
       "Bash(rm -rf:*)",


### PR DESCRIPTION
- Replace `Skill(base:*)` wildcard with explicit skill permissions in both personal and work settings
- Add individual entries for `creating-branch-name`, `splitting-commit`, `formatting-commit`, and `creating-pr`