### PR TITLE
[main] chore: add Copilot CLI config

### DIFF
--- a/.config/copilot/copilot-instructions.md
+++ b/.config/copilot/copilot-instructions.md
@@ -1,0 +1,21 @@
+# copilot-instructions.md
+
+## Communication
+- Always communicate in Japanese
+- Code comments in English
+- Do not use emojis unless explicitly instructed
+- Do not use bold text (**text**) in responses
+
+## Security
+
+### NEVER
+- Delete production data without explicit confirmation
+- Hardcode secrets
+- Commit with test/lint errors
+
+### MUST
+- Write tests for new features and bug fixes
+- Document breaking changes
+
+## Proactive
+- Suggest improvements proactively

--- a/.config/nix/home-manager/dotfiles.nix
+++ b/.config/nix/home-manager/dotfiles.nix
@@ -26,6 +26,11 @@ let
     "settings.json"
   ];
 
+  # Copilot config files (stored in .config/copilot/, linked to ~/.copilot/)
+  copilotFiles = [
+    "copilot-instructions.md"
+  ];
+
   # Codex config files (stored in .config/codex/, linked to ~/.codex/)
   # Note: config.toml is excluded from symlinks because Codex writes runtime
   # state (project trust levels) to it. It is bootstrapped via activation script.
@@ -47,7 +52,10 @@ in
   }) geminiFiles) // builtins.listToAttrs (map (file: {
     name = ".codex/${file}";
     value = { source = mkLink ".config/codex/${file}"; };
-  }) codexFiles) // {
+  }) codexFiles) // builtins.listToAttrs (map (file: {
+    name = ".copilot/${file}";
+    value = { source = mkLink ".config/copilot/${file}"; };
+  }) copilotFiles) // {
     # Claude settings (host-specific: personal uses settings.json, work uses settings-work.json)
     ".claude/settings.json".source = mkLink ".config/claude/${claudeSettingsFile}";
     # SSH public key

--- a/.config/nix/hosts/common/homebrew.nix
+++ b/.config/nix/hosts/common/homebrew.nix
@@ -8,6 +8,7 @@
     ];
 
     casks = [
+      "copilot-cli"
       "google-chrome"
       "karabiner-elements"
       "logi-options+"


### PR DESCRIPTION
- Add copilot-cli Homebrew cask for all hosts
- Add copilot-instructions.md with communication and security guidelines
- Add symlink management in dotfiles.nix to link .config/copilot/ to ~/.copilot/