### PR TITLE
[main] chore: remove managed macOS system defaults

### DIFF
--- a/.config/nix/darwin/system.nix
+++ b/.config/nix/darwin/system.nix
@@ -15,71 +15,25 @@
 
   security.pam.services.sudo_local = {
     touchIdAuth = true;
-    # watchIdAuth = true;
   };
 
   system.defaults = {
-    ".GlobalPreferences" = {
-      "com.apple.mouse.scaling" = 0.875;
-    };
-
-    dock = {
-      autohide = true;
-      persistent-apps = [
-        { app = "/Applications/Google Chrome.app"; }
-      ] ++ (lib.optionals config.hostSpec.isWork [
-        { app = "/Applications/Slack.app"; }
-      ]) ++ [
-        { app = "/Applications/Zed.app"; }
-        { app = "/Applications/Ghostty.app"; }
-      ] ++ (lib.optionals (!config.hostSpec.isWork) [
-        { app = "/Applications/Obsidian.app"; }
-      ]);
-      show-recents = false;
-      tilesize = 40;
-    };
-
     finder = {
       AppleShowAllExtensions = true;
       AppleShowAllFiles = true;
-      FXDefaultSearchScope = "SCev";
-      FXPreferredViewStyle = "Nlsv";
-      NewWindowTarget = "Home";
-      ShowExternalHardDrivesOnDesktop = false;
       ShowPathbar = true;
       ShowStatusBar = true;
     };
 
     NSGlobalDomain = {
-      AppleICUForce24HourTime = false;
-      AppleInterfaceStyle = "Dark";
-      AppleMeasurementUnits = "Centimeters";
-      AppleMetricUnits = 1;
       AppleShowScrollBars = "Always";
-      AppleTemperatureUnit = "Celsius";
       InitialKeyRepeat = 18;
       KeyRepeat = 1;
-      NSDocumentSaveNewDocumentsToCloud = false;
-      NSNavPanelExpandedStateForSaveMode = true;
-      NSNavPanelExpandedStateForSaveMode2 = true;
-      PMPrintingExpandedStateForPrint = true;
-      PMPrintingExpandedStateForPrint2 = true;
     };
 
     screencapture = {
       location = "~/Desktop/screenshots";
       show-thumbnail = false;
-    };
-
-    menuExtraClock = {
-      FlashDateSeparators = false;
-      IsAnalog = false;
-      Show24Hour = true;
-      ShowAMPM = false;
-      ShowDate = 0;
-      ShowDayOfMonth = true;
-      ShowDayOfWeek = true;
-      ShowSeconds = true;
     };
   };
 


### PR DESCRIPTION
- Remove Dock settings (autohide, persistent-apps, show-recents, tilesize)
- Remove Finder search scope, view style, and default window target settings
- Remove mouse scaling, screensaver, and Spaces auto-rearrange settings
- Retain Finder visibility settings, key repeat, scroll bars, and screenshot config