### PR TITLE
[main] chore: add caffeinate abbreviation

### DIFF
--- a/.config/nix/home-manager/programs/zsh.nix
+++ b/.config/nix/home-manager/programs/zsh.nix
@@ -49,6 +49,7 @@ in
         v = "vim";
         g = "git";
         "z." = "zed .";
+        cf = "caffeinate -id";
 
         # Docker
         dc = "docker compose";


### PR DESCRIPTION
- Add `cf` abbreviation for `caffeinate -id` in zsh-abbr
- Prevent system and display sleep during long-running tasks (e.g. Claude Code sessions)