### PR TITLE
[main] chore: tune work claude settings for higher effort and auto teammate

### DIFF
--- a/.config/claude/settings-work.json
+++ b/.config/claude/settings-work.json
@@ -129,7 +129,8 @@
     "sentry@claude-plugins-official": true,
     "notion@claude-plugins-official": true
   },
-  "effortLevel": "high",
+  "effortLevel": "xhigh",
   "promptSuggestionEnabled": false,
-  "voiceEnabled": true
+  "voiceEnabled": true,
+  "teammateMode": "auto"
 }


### PR DESCRIPTION
- Raise effortLevel from high to xhigh in work Claude settings
- Enable teammateMode set to auto for the work host