### PR TITLE
[main] fix: switch pnpm to npm backend in mise

### DIFF
--- a/.config/nix/home-manager/programs/mise.nix
+++ b/.config/nix/home-manager/programs/mise.nix
@@ -8,7 +8,7 @@
     globalConfig = {
       tools = {
         node = "latest";
-        pnpm = "latest";
+        "npm:pnpm" = "latest";
         "npm:yarn" = "latest";
         "npm:@fission-ai/openspec" = "latest";
         "npm:@google/gemini-cli" = "latest";


### PR DESCRIPTION
- Switch pnpm tool source from aqua to the npm backend in mise.nix
- Fix `mise upgrade` failure caused by aqua-registry still expecting `pnpm-macos-arm64` while pnpm v11.0.0+ ships the darwin asset as `pnpm-darwin-arm64.tar.gz`