### PR TITLE
[main] chore: update flake inputs and enable brew upgrade

### DIFF
--- a/.config/claude/settings-work.json
+++ b/.config/claude/settings-work.json
@@ -89,7 +89,6 @@
       "Bash(aws cloudformation update-stack:*)"
     ]
   },
-  "model": "opus[1m]",
   "hooks": {
     "PreToolUse": [
       {
@@ -127,10 +126,12 @@
     "serena@claude-plugins-official": true,
     "hookify@claude-plugins-official": true,
     "sentry@claude-plugins-official": true,
-    "notion@claude-plugins-official": true
+    "notion@claude-plugins-official": true,
+    "softphone-team@revcomm": true
   },
   "effortLevel": "xhigh",
   "promptSuggestionEnabled": false,
-  "voiceEnabled": true,
-  "teammateMode": "auto"
+  "autoMemoryEnabled": true,
+  "teammateMode": "auto",
+  "voiceEnabled": true
 }

--- a/.config/nix/darwin/homebrew.nix
+++ b/.config/nix/darwin/homebrew.nix
@@ -5,6 +5,7 @@
     enable = true;
     onActivation = {
       autoUpdate = true;
+      upgrade = true;
       cleanup = "uninstall";
     };
     taps = [

--- a/.config/nix/flake.lock
+++ b/.config/nix/flake.lock
@@ -26,16 +26,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1769363988,
-        "narHash": "sha256-BiGPeulrDVetXP+tjxhMcGLUROZAtZIhU5m4MqawCfM=",
+        "lastModified": 1778427648,
+        "narHash": "sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "d01011cac6d72032c75fd2cd9489909e95d9faf2",
+        "rev": "6f293daa9f9f5832e13b497976335e90509886d7",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.0.12",
+        "ref": "5.1.11",
         "repo": "brew",
         "type": "github"
       }
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773000227,
-        "narHash": "sha256-zm3ftUQw0MPumYi91HovoGhgyZBlM4o3Zy0LhPNwzXE=",
+        "lastModified": 1779036909,
+        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "da529ac9e46f25ed5616fd634079a5f3c579135f",
+        "rev": "56c666e108467d87d13508936aade6d567f2a501",
         "type": "github"
       },
       "original": {
@@ -110,11 +110,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773422513,
-        "narHash": "sha256-MPjR48roW7CUMU6lu0+qQGqj92Kuh3paIulMWFZy+NQ=",
+        "lastModified": 1779336838,
+        "narHash": "sha256-n1+l78hJRABp4cQHKeD0BVByT0vZLPqd09Tvoq8Q+d8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ef12a9a2b0f77c8fa3dda1e7e494fca668909056",
+        "rev": "928d72376949e222ea4f07b44828a55b0136422e",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1773465442,
-        "narHash": "sha256-+2szU/l3F+iX+AtS3pYdL8hMp9hZWmFstN2LoJzkdo0=",
+        "lastModified": 1779342375,
+        "narHash": "sha256-1c0r4KttgKu6JdZJ4UU7sIe4NQ0J74yjeERkBrORMvU=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "4c23dd6ad879595a340264632bd7be5234bf6e37",
+        "rev": "d802d36c74a909788d61bf12285cbb69e3b01cf3",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1773465375,
-        "narHash": "sha256-VYS8J7PoB+J59AuIdGJgAlksNn7vnPQ8d6ukrXO/JYQ=",
+        "lastModified": 1779340637,
+        "narHash": "sha256-VlNLyIdjRXgsArPOabIYbALog/nZ6fKjLhHyCCo5z/g=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "dcc0ba70960e426ae850c3a970af479e98a450bc",
+        "rev": "2502a905d047a23ac31741463c7702d41a94bc81",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1769437432,
-        "narHash": "sha256-8d7KnCpT2LweRvSzZYEGd9IM3eFX+A78opcnDM0+ndk=",
+        "lastModified": 1778851564,
+        "narHash": "sha256-p8wzcnpB2Iys+QzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "a5409abd0d5013d79775d3419bcac10eacb9d8c5",
+        "rev": "b3a87b4793205cc111f3c61e25e018ffac3b8039",
         "type": "github"
       },
       "original": {
@@ -175,11 +175,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773231277,
-        "narHash": "sha256-Xy3WEpUAbpsz8ydgvVAQAGGB/WB+8cNA5cshiL0McTI=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "75690239f08f885ca9b0267580101f60d10fbe62",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- Update flake inputs (nix-darwin, home-manager, nixpkgs, nix-homebrew, brew 5.1.11, homebrew-cask/core)
- Enable automatic Homebrew package upgrades on activation via homebrew.upgrade = true
- Tune work Claude settings: drop hardcoded model override, enable softphone-team marketplace and autoMemory