### PR TITLE
[main] chore: align claude permissions with plugin namespaces

### DIFF
--- a/.config/claude/settings-work.json
+++ b/.config/claude/settings-work.json
@@ -15,15 +15,12 @@
       "Edit",
       "Write",
       "WebFetch",
-      "mcp__context7",
-      "mcp__chrome-devtools",
-      "mcp__serena",
-      "mcp__playwright",
+      "mcp__plugin_context7_context7__*",
       "mcp__plugin_base_serena__*",
-      "Skill(creating-branch-name)",
-      "Skill(splitting-commit)",
-      "Skill(formatting-commit)",
-      "Skill(creating-pr)"
+      "mcp__plugin_base_chrome-devtools__*",
+      "mcp__plugin_base_playwright__*",
+      "mcp__plugin_base_astro-docs__*",
+      "Skill(base:*)"
     ],
     "deny": [
       "Bash(rm -rf:*)",

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -124,5 +124,6 @@
   },
   "effortLevel": "high",
   "promptSuggestionEnabled": false,
-  "voiceEnabled": true
+  "voiceEnabled": true,
+  "model": "opus[1m]"
 }

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -15,15 +15,12 @@
       "Edit",
       "Write",
       "WebFetch",
-      "mcp__context7",
-      "mcp__chrome-devtools",
-      "mcp__serena",
-      "mcp__playwright",
+      "mcp__plugin_context7_context7__*",
       "mcp__plugin_base_serena__*",
-      "Skill(creating-branch-name)",
-      "Skill(splitting-commit)",
-      "Skill(formatting-commit)",
-      "Skill(creating-pr)"
+      "mcp__plugin_base_chrome-devtools__*",
+      "mcp__plugin_base_playwright__*",
+      "mcp__plugin_base_astro-docs__*",
+      "Skill(base:*)"
     ],
     "deny": [
       "Bash(rm -rf:*)",


### PR DESCRIPTION
- Switch personal and work allow lists from legacy mcp__ prefixes to plugin-prefixed namespaces (mcp__plugin_context7_context7__*, mcp__plugin_base_chrome-devtools__*, mcp__plugin_base_playwright__*, mcp__plugin_base_astro-docs__*)
- Replace individual Skill(creating-branch-name|splitting-commit|formatting-commit|creating-pr) entries with the broader Skill(base:*) wildcard
- Pin personal settings.json model to opus[1m]