### PR TITLE
[main] chore: add modern-web-guidance plugin

### DIFF
--- a/.config/claude/settings-work.json
+++ b/.config/claude/settings-work.json
@@ -125,7 +125,16 @@
     "hookify@claude-plugins-official": true,
     "sentry@claude-plugins-official": true,
     "notion@claude-plugins-official": true,
-    "softphone-team@revcomm": true
+    "softphone-team@revcomm": true,
+    "modern-web-guidance@googlechrome": true
+  },
+  "extraKnownMarketplaces": {
+    "googlechrome": {
+      "source": {
+        "source": "github",
+        "repo": "GoogleChrome/modern-web-guidance"
+      }
+    }
   },
   "effortLevel": "xhigh",
   "promptSuggestionEnabled": false,

--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -121,7 +121,16 @@
     "context7@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,
     "serena@claude-plugins-official": true,
-    "hookify@claude-plugins-official": true
+    "hookify@claude-plugins-official": true,
+    "modern-web-guidance@googlechrome": true
+  },
+  "extraKnownMarketplaces": {
+    "googlechrome": {
+      "source": {
+        "source": "github",
+        "repo": "GoogleChrome/modern-web-guidance"
+      }
+    }
   },
   "effortLevel": "high",
   "promptSuggestionEnabled": false,


### PR DESCRIPTION
- Register GoogleChrome/modern-web-guidance marketplace under extraKnownMarketplaces in both personal and work settings
- Enable modern-web-guidance@googlechrome plugin in personal and work Claude configurations