### PR TITLE
[main] feat: show cache hit rate in statusline

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -129,6 +129,5 @@
   },
   "effortLevel": "high",
   "promptSuggestionEnabled": false,
-  "voiceEnabled": true,
-  "model": "opus[1m]"
+  "voiceEnabled": true
 }

--- a/.config/claude/statusline-command.sh
+++ b/.config/claude/statusline-command.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Claude Code statusLine script
-# Output format: Sonnet 4.6 | main | 10.2K (20%) | 5h 42% | 7d 86%
+# Output format: Sonnet 4.6 | main | 10.2K (20%) | cache hit 94% (read 47.2K / write 2.6K) | 5h 42% | 7d 86%
 
 input=$(cat)
 
@@ -15,6 +15,12 @@ used_tokens=$(echo "$input" | jq -r '
   | if . == 0 then empty else . end
 ')
 
+# cache breakdown from the last API response (null before first call / right after /compact)
+cache_read=$(echo "$input" | jq -r '.context_window.current_usage.cache_read_input_tokens // 0')
+cache_write=$(echo "$input" | jq -r '.context_window.current_usage.cache_creation_input_tokens // 0')
+cache_input=$(echo "$input" | jq -r '.context_window.current_usage.input_tokens // 0')
+cache_total=$(( cache_read + cache_write + cache_input ))
+
 five_hour_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
 seven_day_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
 
@@ -28,12 +34,29 @@ pct_color() {
   else printf '\033[32m'; fi
 }
 
+# inverse of pct_color: high cache hit rate is good (green)
+cache_color() {
+  local pct=$1
+  if [[ "$pct" -ge 80 ]]; then printf '\033[32m'
+  elif [[ "$pct" -ge 50 ]]; then printf '\033[33m'
+  else printf '\033[31m'; fi
+}
+
+# format a token count as "12.3K" (drop the .0 for whole values)
+fmt_k() {
+  awk "BEGIN {printf \"%.1fK\", $1 / 1000}" | sed 's/\.0K/K/'
+}
+
 if [[ -n "$used_pct" && -n "$used_tokens" ]]; then
   pct=$(printf "%.0f" "$used_pct")
-  fmt_k=$(awk "BEGIN {printf \"%.1fK\", $used_tokens / 1000}" | sed 's/\.0K/K/')
-  printf "%s%s | %s (%b%s%%\033[0m)" "$model" "$branch_part" "$fmt_k" "$(pct_color "$pct")" "$pct"
+  printf "%s%s | %s (%b%s%%\033[0m)" "$model" "$branch_part" "$(fmt_k "$used_tokens")" "$(pct_color "$pct")" "$pct"
 else
   printf "%s%s | --" "$model" "$branch_part"
+fi
+
+if [[ "$cache_total" -gt 0 ]]; then
+  hit=$(( cache_read * 100 / cache_total ))
+  printf " | cache hit %b%s%%\033[0m (read %s / write %s)" "$(cache_color "$hit")" "$hit" "$(fmt_k "$cache_read")" "$(fmt_k "$cache_write")"
 fi
 
 if [[ -n "$five_hour_pct" ]]; then


### PR DESCRIPTION
- Add cache hit rate display to the statusline (read/write token breakdown)
- Add cache_color helper that greens high hit rates and reds low ones
- Extract fmt_k token-formatting helper and reuse it for context usage
- Remove the pinned opus[1m] model from settings to follow the default